### PR TITLE
Made plugin data available in the global variable scope in the template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 npm-debug.log
 node_modules/
 lib/
+public/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ config file (such as `brunch-config.coffee`):
 
 * __pathReplace__: _(RegExp)_ Sets the regular expression applied against the source file path to create the module name. Matched characters are removed. Default `/^app(\/|\\)views(\/|\\).*.html$/`
 
+All other data in `plugins.nunjucks` will be made available in the template's local scope.
+
 **Example:**
 ```coffeescript
 exports.config =
@@ -26,6 +28,7 @@ exports.config =
   plugins:
     nunjucks:
       pathReplace: /^app(\/|\\)views(\/|\\).*.html$/
+      customLocalVar: 'whatever I want'
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-brunch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Adds nunjucks support to brunch.",
   "author": {
     "name": "Daniel Jost",
@@ -18,7 +18,8 @@
   ],
   "main": "./src/index.coffee",
   "scripts": {
-    "prepublish": "rm -rf lib && coffee --bare --output lib/ src/"
+    "prepublish": "rm -rf lib && coffee --bare --output lib/ src/",
+    "test": "mocha test.coffee --watch --compilers coffee:coffee-script/register"
   },
   "license": "MIT",
   "dependencies": {
@@ -27,7 +28,10 @@
     "mkdirp": "0.3.5"
   },
   "devDependencies": {
-    "coffee-script": "~1.6.3"
+    "chai": "^1.10.0",
+    "coffee-script": "~1.9.0",
+    "mocha": "^2.1.0",
+    "sinon": "^1.12.2"
   },
   "readmeFilename": "README.md",
   "bugs": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -57,7 +57,7 @@ module.exports = class nunjucksBrunchPlugin
   templateFactory: ( data, options, templatePath, callback ) ->
     try
       env = new nunjucks.Environment ( new nunjucks.FileSystemLoader ( path.dirname templatePath ) )
-      template = env.renderString data
+      template = env.renderString data, options
     catch e
       error = e
 
@@ -67,7 +67,7 @@ module.exports = class nunjucksBrunchPlugin
     templatePath = path.resolve originalPath
     relativePath = path.relative @projectPath, templatePath
 
-    options = _.extend {}, @options
+    options = _.extend {}, @nunjucksOptions
     options.filename ?= relativePath
 
     successHandler = ( error, template ) =>

--- a/test.coffee
+++ b/test.coffee
@@ -1,0 +1,29 @@
+fs = require 'fs'
+expect = require('chai').expect
+nunjucks = require 'nunjucks'
+Plugin = require './'
+
+describe 'Plugin', ->
+  @plugin
+
+  beforeEach ->
+    @plugin = new Plugin
+      plugins:
+        nunjucks:
+          weak: 'So so strong'
+
+  it 'should be an object', ->
+    expect(@plugin).to.be.ok
+
+  it 'should has #compile method', ->
+    expect(@plugin.compile).to.be.an.instanceof(Function);
+
+  it 'should pass `plugins.nunjucks` data to the template', (done) ->
+    content = '<strong>{{weak}}</strong>';
+    expected = '<strong>So so strong</strong>';
+
+    @plugin.compile content, 'template.nunjucks', (err) ->
+      expect(err).not.to.be.ok;
+      result = fs.readFileSync __dirname + '/public/template.nunjucks', { encoding: 'UTF-8' }
+      expect(result).to.equal(expected);
+      done()


### PR DESCRIPTION
It looks like @PxlBuzzard intended arbitrary nunjucks options to be available in the global variable scope of the templates, allowing for rendering stuff like:

```
Hello {{ username }}
```

This pull request completes that feature and adds a unit test for it. I also bumped the version to `0.2.1`.
